### PR TITLE
Add `.DS_Store` to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 caddy
+.DS_Store


### PR DESCRIPTION
### FabGPT — l0-git remediation

**Gate:** `gitignore_coverage` · **Confidence:** deterministic

.gitignore does not cover `.DS_Store`. Generated by macOS/Windows/IDEs; never relevant to the project. Add `.DS_Store` to your .gitignore.

_Approved by a human before opening._

---
🤖 **FabGPT OS** · source `l0git` · model `deterministic` · task `44458db1e723f190` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"44458db1e723f190","source":"l0git","model":"deterministic","severity":"INFO","iterations":1,"inference_s":0.0,"triage":"INFO"} -->